### PR TITLE
feat: async-local-storage-store package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,10 @@
       "resolved": "packages/cache-common",
       "link": true
     },
+    "node_modules/@anchan828/nest-cache-manager-async-local-storage": {
+      "resolved": "packages/cache-manager-async-local-storage",
+      "link": true
+    },
     "node_modules/@anchan828/nest-cache-manager-ioredis": {
       "resolved": "packages/cache-manager-ioredis",
       "link": true
@@ -13048,6 +13052,7 @@
         "cache-manager": "^5.1.4"
       },
       "devDependencies": {
+        "@anchan828/nest-cache-manager-async-local-storage": "^2.0.16",
         "@anchan828/nest-cache-manager-ioredis": "^2.0.16",
         "@anchan828/nest-cache-manager-memory": "^2.0.16",
         "@nestjs/common": "^9.2.1",
@@ -13071,6 +13076,15 @@
         "@nestjs/common": "^9.2.1"
       }
     },
+    "packages/cache-manager-async-local-storage": {
+      "name": "@anchan828/nest-cache-manager-async-local-storage",
+      "version": "2.0.16",
+      "license": "MIT",
+      "dependencies": {
+        "@anchan828/nest-cache-common": "^2.0.16",
+        "cache-manager": "^5.1.4"
+      }
+    },
     "packages/cache-manager-ioredis": {
       "name": "@anchan828/nest-cache-manager-ioredis",
       "version": "2.0.16",
@@ -13090,6 +13104,7 @@
       "version": "2.0.16",
       "license": "MIT",
       "dependencies": {
+        "@anchan828/nest-cache-common": "^2.0.16",
         "cache-manager": "^5.1.4"
       }
     }
@@ -13109,6 +13124,7 @@
       "version": "file:packages/cache",
       "requires": {
         "@anchan828/nest-cache-common": "^2.0.16",
+        "@anchan828/nest-cache-manager-async-local-storage": "^2.0.16",
         "@anchan828/nest-cache-manager-ioredis": "^2.0.16",
         "@anchan828/nest-cache-manager-memory": "^2.0.16",
         "@nestjs/common": "^9.2.1",
@@ -13125,6 +13141,13 @@
         "rxjs": "^7.8.0"
       }
     },
+    "@anchan828/nest-cache-manager-async-local-storage": {
+      "version": "file:packages/cache-manager-async-local-storage",
+      "requires": {
+        "@anchan828/nest-cache-common": "^2.0.16",
+        "cache-manager": "^5.1.4"
+      }
+    },
     "@anchan828/nest-cache-manager-ioredis": {
       "version": "file:packages/cache-manager-ioredis",
       "requires": {
@@ -13138,6 +13161,7 @@
     "@anchan828/nest-cache-manager-memory": {
       "version": "file:packages/cache-manager-memory",
       "requires": {
+        "@anchan828/nest-cache-common": "^2.0.16",
         "cache-manager": "^5.1.4"
       }
     },

--- a/packages/cache-common/src/async-local-storage.service.ts
+++ b/packages/cache-common/src/async-local-storage.service.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "async_hooks";
-import { ASYNC_LOCAL_STORAGE_PREFIX } from "./constants";
+export const ASYNC_LOCAL_STORAGE_PREFIX = "nest-cache:";
 
 function clone<T = any>(value: T): T {
   if (typeof value === "object") {
@@ -23,6 +23,24 @@ export class AsyncLocalStorageService {
 
   public delete<T = any>(key: string): void {
     this.getStore<T>()?.delete(this.keyPrefix(key));
+  }
+
+  public keys(pattern?: string): string[] {
+    const store = this.getStore();
+
+    let keys = Array.from(store?.keys() || []);
+
+    keys = keys
+      .filter((key) => key)
+      .filter((key) => key && key.startsWith(ASYNC_LOCAL_STORAGE_PREFIX))
+      .map((key) => key.replace(ASYNC_LOCAL_STORAGE_PREFIX, ""));
+
+    if (pattern) {
+      const regexpPattern = pattern.replace(new RegExp(/\*/, "g"), ".*");
+      keys = keys.filter((key) => key.match(`^${regexpPattern}`));
+    }
+
+    return keys;
   }
 
   public clear(): void {

--- a/packages/cache-common/src/index.ts
+++ b/packages/cache-common/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./async-local-storage.service";
 export * from "./chunk";
 export * from "./interfaces";
 export * from "./is-null-or-undefeind";

--- a/packages/cache-manager-async-local-storage/.eslintrc.js
+++ b/packages/cache-manager-async-local-storage/.eslintrc.js
@@ -1,0 +1,3 @@
+const baseESLintConfig = require("../../.eslintrc");
+
+module.exports = { ...baseESLintConfig };

--- a/packages/cache-manager-async-local-storage/.npmignore
+++ b/packages/cache-manager-async-local-storage/.npmignore
@@ -1,0 +1,3 @@
+*
+!dist/**/*
+dist/**/*.tsbuildinfo

--- a/packages/cache-manager-async-local-storage/.prettierrc.js
+++ b/packages/cache-manager-async-local-storage/.prettierrc.js
@@ -1,0 +1,5 @@
+const basePrettierConfig = require("../../.prettierrc");
+
+module.exports = {
+  ...basePrettierConfig,
+};

--- a/packages/cache-manager-async-local-storage/README.md
+++ b/packages/cache-manager-async-local-storage/README.md
@@ -1,0 +1,35 @@
+# @anchan828/nest-cache-manager-async-local-storage
+
+![npm](https://img.shields.io/npm/v/@anchan828/nest-cache-manager-async-local-storage.svg)
+![NPM](https://img.shields.io/npm/l/@anchan828/nest-cache-manager-async-local-storage.svg)
+
+## Description
+
+AsyncLocalStorage store for node-cache-manager.
+
+## Installation
+
+```bash
+$ npm i --save @anchan828/nest-cache-manager-async-local-storage
+```
+
+## Quick Start
+
+```ts
+import { asyncLocalStorageStore } from "@anchan828/nest-cache-manager-async-local-storage";
+import { caching } from "cache-manager";
+
+caching({
+  store: asyncLocalStorageStore,
+  asyncLocalStorage: new AsyncLocalStorage<Map<string, any>>(),
+});
+```
+
+## Notes
+
+- This package is a cache function that is enabled only during a request using AsyncLocalStorage.
+  - It is useful when the same data is retrieved from the database many times during a request, although it does not need to be cached permanently, such as in memory or Redis.
+
+## License
+
+[MIT](LICENSE)

--- a/packages/cache-manager-async-local-storage/README.md
+++ b/packages/cache-manager-async-local-storage/README.md
@@ -19,9 +19,15 @@ $ npm i --save @anchan828/nest-cache-manager-async-local-storage
 import { asyncLocalStorageStore } from "@anchan828/nest-cache-manager-async-local-storage";
 import { caching } from "cache-manager";
 
-caching({
+const asyncLocalStorage = new AsyncLocalStorage<Map<string, any>>();
+
+const cache = caching({
   store: asyncLocalStorageStore,
-  asyncLocalStorage: new AsyncLocalStorage<Map<string, any>>(),
+  asyncLocalStorage,
+});
+
+asyncLocalStorage.run(new Map<string, any>(), () => {
+  cache.get("key");
 });
 ```
 

--- a/packages/cache-manager-async-local-storage/jest.config.js
+++ b/packages/cache-manager-async-local-storage/jest.config.js
@@ -1,0 +1,4 @@
+const base = require("../../jest.config.base");
+module.exports = {
+  ...base,
+};

--- a/packages/cache-manager-async-local-storage/package-lock.json
+++ b/packages/cache-manager-async-local-storage/package-lock.json
@@ -1,0 +1,358 @@
+{
+	"name": "@anchan828/nest-cache-manager-ioredis",
+	"version": "2.0.16",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "@anchan828/nest-cache-manager-ioredis",
+			"version": "2.0.16",
+			"license": "MIT",
+			"dependencies": {
+				"@anchan828/nest-cache-common": "^2.0.16",
+				"cache-manager": "^5.1.4",
+				"ioredis": "^5.2.5",
+				"msgpackr": "^1.8.1"
+			},
+			"devDependencies": {
+				"ioredis-mock": "^8.2.2"
+			},
+			"peerDependencies": {
+				"@nestjs/common": "^8.0.0",
+				"lru-cache": "^7.0.0"
+			}
+		},
+		"node_modules/@ioredis/commands": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.1.1.tgz",
+			"integrity": "sha512-fsR4P/ROllzf/7lXYyElUJCheWdTJVJvOTps8v9IWKFATxR61ANOlnoPqhH099xYLrJGpc2ZQ28B3rMeUt5VQg=="
+		},
+		"node_modules/async": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+		},
+		"node_modules/axios": {
+			"version": "0.26.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+			"dev": true,
+			"dependencies": {
+				"follow-redirects": "^1.14.8"
+			}
+		},
+		"node_modules/cluster-key-slot": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+			"integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/denque": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+			"integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/follow-redirects": {
+			"version": "1.14.8",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+			"integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/iterare": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
+			"integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
+		"node_modules/lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+		},
+		"node_modules/lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+		},
+		"node_modules/ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"node_modules/redis-errors": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+			"integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/redis-parser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+			"integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+			"dependencies": {
+				"redis-errors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/reflect-metadata": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/standard-as-callback": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+		},
+		"node_modules/tslib": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"dev": true
+		},
+		"node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"dev": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
+			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		}
+	},
+	"dependencies": {
+		"@ioredis/commands": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.1.1.tgz",
+			"integrity": "sha512-fsR4P/ROllzf/7lXYyElUJCheWdTJVJvOTps8v9IWKFATxR61ANOlnoPqhH099xYLrJGpc2ZQ28B3rMeUt5VQg=="
+		},
+		"@nestjs/common": {
+			"version": "8.4.4",
+			"resolved": "https://registry.npmjs.org/@nestjs/common/-/common-8.4.4.tgz",
+			"integrity": "sha512-QHi7QcgH/5Jinz+SCfIZJkFHc6Cch1YsAEGFEhi6wSp6MILb0sJMQ1CX06e9tCOAjSlBwaJj4PH0eFCVau5v9Q==",
+			"dev": true,
+			"requires": {
+				"axios": "0.26.1",
+				"iterare": "1.2.1",
+				"tslib": "2.3.1",
+				"uuid": "8.3.2"
+			}
+		},
+		"@types/cache-manager": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/@types/cache-manager/-/cache-manager-3.4.3.tgz",
+			"integrity": "sha512-71aBXoFYXZW4TnDHHH8gExw2lS28BZaWeKefgsiJI7QYZeJfUEbMKw6CQtzGjlYQcGIWwB76hcCrkVA3YHSvsw==",
+			"dev": true
+		},
+		"async": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
+		},
+		"axios": {
+			"version": "0.26.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+			"integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+			"dev": true,
+			"requires": {
+				"follow-redirects": "^1.14.8"
+			}
+		},
+		"cache-manager": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-3.6.1.tgz",
+			"integrity": "sha512-jxJvGYhN5dUgpriAdsDnnYbKse4dEXI5i3XpwTfPq5utPtXH1uYXWyGLHGlbSlh9Vq4ytrgAUVwY+IodNeKigA==",
+			"requires": {
+				"async": "3.2.3",
+				"lodash": "^4.17.21",
+				"lru-cache": "6.0.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				}
+			}
+		},
+		"cluster-key-slot": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+			"integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+		},
+		"debug": {
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"requires": {
+				"ms": "2.1.2"
+			}
+		},
+		"denque": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+			"integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+		},
+		"follow-redirects": {
+			"version": "1.14.8",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+			"integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==",
+			"dev": true
+		},
+		"ioredis": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.0.4.tgz",
+			"integrity": "sha512-qFJw3MnPNsJF1lcIOP3vztbsasOXK3nDdNAgjQj7t7/Bn/w10PGchTOpqylQNxjzPbLoYDu34LjeJtSWiKBntQ==",
+			"requires": {
+				"@ioredis/commands": "^1.1.1",
+				"cluster-key-slot": "^1.1.0",
+				"debug": "^4.3.4",
+				"denque": "^2.0.1",
+				"lodash.defaults": "^4.2.0",
+				"lodash.isarguments": "^3.1.0",
+				"redis-errors": "^1.2.0",
+				"redis-parser": "^3.0.0",
+				"standard-as-callback": "^2.1.0"
+			}
+		},
+		"iterare": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
+			"integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+			"dev": true
+		},
+		"lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+		},
+		"lodash.defaults": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+			"integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+		},
+		"lodash.isarguments": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+		},
+		"lru-cache": {
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.1.tgz",
+			"integrity": "sha512-E1v547OCgJvbvevfjgK9sNKIVXO96NnsTsFPBlg4ZxjhsJSODoH9lk8Bm0OxvHNm6Vm5Yqkl/1fErDxhYL8Skg=="
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"redis-errors": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+			"integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+		},
+		"redis-parser": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+			"integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+			"requires": {
+				"redis-errors": "^1.0.0"
+			}
+		},
+		"reflect-metadata": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+			"integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+			"dev": true,
+			"peer": true
+		},
+		"rxjs": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+			"integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+			"dev": true,
+			"requires": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"standard-as-callback": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+			"integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
+		},
+		"tslib": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+			"dev": true
+		},
+		"uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"dev": true
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		}
+	}
+}

--- a/packages/cache-manager-async-local-storage/package.json
+++ b/packages/cache-manager-async-local-storage/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@anchan828/nest-cache",
+  "name": "@anchan828/nest-cache-manager-async-local-storage",
   "version": "2.0.16",
   "description": "",
   "homepage": "https://github.com/anchan828/nest-cache#readme",
@@ -20,11 +20,9 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "copy:license": "cp ../../LICENSE ./",
-    "copy:readme": "cp ../../README.md ./",
     "lint": "TIMING=1 eslint --ignore-path ../../.eslintignore '**/*.ts'",
     "lint:fix": "npm run lint -- --fix",
-    "prepublishOnly": "npm run copy:license && npm run copy:readme",
-    "test": "jest --coverage --runInBand",
+    "test": "jest --coverage --runInBand --detectOpenHandles",
     "test:debug": "node --inspect-brk ../../node_modules/jest/bin/jest --runInBand --logHeapUsage",
     "test:watch": "npm run test -- --watch",
     "watch": "tsc --watch"
@@ -32,17 +30,6 @@
   "dependencies": {
     "@anchan828/nest-cache-common": "^2.0.16",
     "cache-manager": "^5.1.4"
-  },
-  "devDependencies": {
-    "@anchan828/nest-cache-manager-async-local-storage": "^2.0.16",
-    "@anchan828/nest-cache-manager-ioredis": "^2.0.16",
-    "@anchan828/nest-cache-manager-memory": "^2.0.16",
-    "@nestjs/common": "^9.2.1",
-    "@nestjs/config": "^2.2.0",
-    "rxjs": "^7.8.0"
-  },
-  "peerDependencies": {
-    "@nestjs/common": "^9.2.1"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/cache-manager-async-local-storage/src/index.ts
+++ b/packages/cache-manager-async-local-storage/src/index.ts
@@ -1,0 +1,2 @@
+export { AsyncLocalStorageStore, asyncLocalStorageStore } from "./store";
+export { AsyncLocalStorageStoreArgs } from "./store.interface";

--- a/packages/cache-manager-async-local-storage/src/store.interface.ts
+++ b/packages/cache-manager-async-local-storage/src/store.interface.ts
@@ -1,0 +1,34 @@
+import { AsyncLocalStorage } from "async_hooks";
+export interface AsyncLocalStorageStoreArgs {
+  /**
+   * The ttl in seconds.
+   * In the AsyncLocalStorage package, ttl works only when set to 0. If set to 0, no caching is performed.
+   * @type {number}
+   * @memberof RedisStoreArgs
+   */
+  ttl?: number;
+
+  /**
+   * Set up an instance of AsyncLocalStorage.
+   *
+   * @type {AsyncLocalStorage<any>}
+   * @memberof RedisStoreArgs
+   */
+  asyncLocalStorage: AsyncLocalStorage<Map<string, any>>;
+
+  hooks?: {
+    /**
+     * Called when the redis cache is hit.
+     */
+    hit?: (key: string, field: string | undefined) => void | Promise<void>;
+
+    /**
+     * Called when a cache is saved to redis.
+     */
+    set?: (key: string, field: string | undefined, value: any, ttl: number | undefined) => void | Promise<void>;
+    /**
+     * Called when a cache is deleted from redis.
+     */
+    delete?: (key: string, field: string | undefined) => void | Promise<void>;
+  };
+}

--- a/packages/cache-manager-async-local-storage/src/store.spec.ts
+++ b/packages/cache-manager-async-local-storage/src/store.spec.ts
@@ -1,0 +1,292 @@
+import { AsyncLocalStorage } from "async_hooks";
+import { AsyncLocalStorageStore, asyncLocalStorageStore } from "./store";
+describe("AsyncLocalStorageStore", () => {
+  let asyncLocalStorage: AsyncLocalStorage<Map<string, any>>;
+  let cache: AsyncLocalStorageStore;
+  let ttl0Cache: AsyncLocalStorageStore;
+  beforeEach(async () => {
+    asyncLocalStorage = new AsyncLocalStorage();
+    cache = asyncLocalStorageStore({ asyncLocalStorage });
+    ttl0Cache = asyncLocalStorageStore({ asyncLocalStorage, ttl: 0 });
+  });
+
+  afterAll(async () => {
+    await cache.close();
+  });
+
+  it("create cache instance", () => {
+    expect(cache).toBeDefined();
+  });
+
+  it("should set cache", async () => {
+    const key = "test";
+    await asyncLocalStorage.run(new Map(), async () => {
+      await expect(cache.get(key)).resolves.toBeUndefined();
+
+      const value = {
+        id: 1,
+        name: "Name",
+        nest: {
+          id: 10,
+        },
+        date: new Date(),
+      };
+
+      await cache.set(key, value, 0);
+
+      await expect(cache.get(key)).resolves.toBeUndefined();
+
+      await ttl0Cache.set(key, value);
+
+      await expect(ttl0Cache.get(key)).resolves.toBeUndefined();
+
+      await cache.set(key, value);
+
+      expect(Array.from(cache["store"].getStore()?.keys() || [])).toEqual(["nest-cache:test"]);
+
+      await expect(cache.get(key)).resolves.toEqual(value);
+
+      expect(Array.from(cache["store"].getStore()?.keys() || [])).toEqual(["nest-cache:test"]);
+    });
+    expect(Array.from(cache["store"].getStore()?.keys() || [])).toEqual([]);
+  });
+  it("should no set undefined", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await cache.set("key", undefined);
+      await cache.set(undefined as any, "value");
+    });
+  });
+
+  it("should no set value when ttl is 0", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await cache.set("test", "value", 0);
+    });
+  });
+
+  it("should set array", async () => {
+    const key = "test";
+    await asyncLocalStorage.run(new Map(), async () => {
+      await cache.set(key, [1, "2", true]);
+      await expect(cache.get(key)).resolves.toEqual([1, "2", true]);
+    });
+  });
+
+  it("should get 0 when undefined key", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await expect(cache.ttl(undefined as any)).resolves.toEqual(0);
+    });
+  });
+
+  it("should always return -1", async () => {
+    const key = "test";
+    await asyncLocalStorage.run(new Map(), async () => {
+      await expect(cache.ttl(key)).resolves.toBeGreaterThanOrEqual(-1);
+    });
+  });
+
+  it("should not try to get value when key is not string", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await expect(cache.get({} as any)).resolves.toBeUndefined();
+    });
+  });
+
+  it("should not delete undefined key", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await expect(cache.del(undefined as any)).resolves.toBeUndefined();
+    });
+  });
+
+  it("should delete cache", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      const key = "test";
+      await asyncLocalStorage.run(new Map(), async () => {
+        await cache.set(key, key);
+        await expect(cache.get(key)).resolves.toEqual(key);
+        await expect(cache.del(key)).resolves.toBeUndefined();
+        await expect(cache.get(key)).resolves.toBeUndefined();
+      });
+    });
+  });
+
+  it("should get cache keys", async () => {
+    const keys = ["key1", "key2", "key3"];
+    await asyncLocalStorage.run(new Map(), async () => {
+      for (const key of keys) {
+        await cache.set(key, key);
+      }
+
+      const results = await cache.keys();
+
+      expect(results.sort()).toEqual(["key1", "key2", "key3"]);
+    });
+  });
+
+  it("should reset cache keys", async () => {
+    const keys = ["key1", "key2", "key3"];
+    await asyncLocalStorage.run(new Map(), async () => {
+      for (const key of keys) {
+        await cache.set(key, key);
+      }
+      let results = await cache.keys();
+      expect(results.sort()).toEqual(["key1", "key2", "key3"]);
+      await cache.reset();
+      results = await cache.keys();
+      expect(results.sort()).toEqual([]);
+    });
+  });
+
+  it("should mget", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      for (const key of ["key1", "key2", "key4"]) {
+        await cache.set(key, `${key}:value`);
+      }
+
+      await expect(cache.mget(...["key1", "key2", "key3", "key4"])).resolves.toEqual([
+        "key1:value",
+        "key2:value",
+        undefined,
+        "key4:value",
+      ]);
+    });
+  });
+
+  it("should mset", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await cache.mset(
+        [
+          ["key1", "key1:value"],
+          ["key2", "key2:value"],
+          ["key3", "key3:value"],
+        ],
+        0,
+      );
+      await expect(cache.keys()).resolves.toEqual([]);
+
+      await ttl0Cache.mset([
+        ["key1", "key1:value"],
+        ["key2", "key2:value"],
+        ["key3", "key3:value"],
+      ]);
+      await expect(ttl0Cache.keys()).resolves.toEqual([]);
+
+      await cache.mset([
+        ["key1", "key1:value"],
+        ["key2", "key2:value"],
+        ["key3", "key3:value"],
+      ]);
+
+      await expect(cache.keys()).resolves.toEqual(["key1", "key2", "key3"]);
+      await expect(cache.mget(...["key1", "key2", "key3"])).resolves.toEqual([
+        "key1:value",
+        "key2:value",
+        "key3:value",
+      ]);
+    });
+  });
+
+  it("should not mset when undefined", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await cache.mset([
+        [undefined as any, "key1:value"],
+        ["key2", undefined],
+        ["key3", "key3:value"],
+      ]);
+      await expect(cache.keys()).resolves.toEqual(["key3"]);
+      await expect(cache.mget(...["key1", "key2", "key3"])).resolves.toEqual([undefined, undefined, "key3:value"]);
+    });
+  });
+
+  it("should not mset when ttl is 0", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await cache.mset(
+        [
+          ["key1", "key1:value"],
+          ["key2", "key2:value"],
+          ["key3", "key3:value"],
+        ],
+        0,
+      );
+      await expect(cache.keys()).resolves.toEqual([]);
+      await expect(cache.mget(...["key1", "key2", "key3"])).resolves.toEqual([undefined, undefined, undefined]);
+    });
+  });
+
+  it("should mdel", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await cache.mset(
+        [
+          ["key1", "key1:value"],
+          ["key2", "key2:value"],
+          ["key3", "key3:value"],
+        ],
+        1000,
+      );
+      await expect(cache.keys()).resolves.toEqual(["key1", "key2", "key3"]);
+      await expect(cache.mdel("key1", "key2", "key3")).resolves.toBeUndefined();
+      await expect(cache.keys()).resolves.toEqual([]);
+      await expect(cache.mget(...["key1", "key2", "key3"])).resolves.toEqual([]);
+    });
+  });
+
+  it("should hget", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await cache.hset("key", "field", "value");
+      await expect(cache.hget("key", "field")).resolves.toEqual("value");
+      await expect(cache.hget("key", "field2")).resolves.toBeUndefined();
+    });
+  });
+
+  it("should not hget when undefined", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await cache.hget("key", undefined as any);
+      await cache.hget(undefined as any, "field");
+    });
+  });
+
+  it("should hset", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await cache.hset("key", "field", "value");
+      await expect(cache.keys()).resolves.toEqual(["key"]);
+      await expect(cache.hkeys("key")).resolves.toEqual(["field"]);
+      await expect(cache.hgetall("key")).resolves.toEqual({ field: "value" });
+    });
+  });
+
+  it("should not hset when undefined", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await expect(cache.hset("key", "field", undefined)).resolves.toBeUndefined();
+      await expect(cache.hset("key", undefined as any, "value")).resolves.toBeUndefined();
+      await expect(cache.hset(undefined as any, "field", "value")).resolves.toBeUndefined();
+    });
+  });
+
+  it("should hdel", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await cache.hset("key", "field", "value");
+      await expect(cache.hget("key", "field")).resolves.toEqual("value");
+      await expect(cache.hdel("key", "field")).resolves.toBeUndefined();
+      await expect(cache.hget("key", "field")).resolves.toBeUndefined();
+    });
+  });
+
+  it("should not hdel when undefined", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await expect(cache.hdel("key", "field")).resolves.toBeUndefined();
+      await expect(cache.hdel("key", undefined as any)).resolves.toBeUndefined();
+      await expect(cache.hdel(undefined as any, ...["field", undefined as any])).resolves.toBeUndefined();
+    });
+  });
+
+  it("should hgetall", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await expect(cache.hgetall("key")).resolves.toEqual({});
+      await expect(cache.hgetall(undefined as any)).resolves.toEqual({});
+    });
+  });
+
+  it("should hkeys", async () => {
+    await asyncLocalStorage.run(new Map(), async () => {
+      await expect(cache.hkeys(undefined as any)).resolves.toEqual([]);
+    });
+  });
+});

--- a/packages/cache-manager-async-local-storage/src/store.ts
+++ b/packages/cache-manager-async-local-storage/src/store.ts
@@ -1,0 +1,191 @@
+/* eslint-disable prefer-rest-params */
+import { AsyncLocalStorageService, CacheManager, isNullOrUndefined } from "@anchan828/nest-cache-common";
+import { AsyncLocalStorage } from "async_hooks";
+import { AsyncLocalStorageStoreArgs } from "./store.interface";
+
+export class AsyncLocalStorageStore implements CacheManager {
+  readonly store: AsyncLocalStorage<Map<string, any>>;
+
+  private readonly asyncLocalStorage: AsyncLocalStorageService;
+
+  constructor(private readonly args: AsyncLocalStorageStoreArgs) {
+    this.asyncLocalStorage = new AsyncLocalStorageService(args.asyncLocalStorage);
+    this.store = args.asyncLocalStorage;
+  }
+
+  public async ttl(key: string): Promise<number> {
+    if (typeof key !== "string") {
+      return 0;
+    }
+    return -1;
+  }
+
+  public async set<T = any>(key: string, value: T, ttl?: number): Promise<void> {
+    if (typeof key !== "string") {
+      return;
+    }
+
+    if (isNullOrUndefined(value)) {
+      return;
+    }
+
+    if (isNullOrUndefined(ttl) && !isNullOrUndefined(this.args.ttl)) {
+      ttl = this.args.ttl;
+    }
+
+    if (ttl === 0) {
+      return;
+    }
+
+    this.asyncLocalStorage.set(key, value);
+
+    await this.args.hooks?.set?.(key, undefined, value, ttl);
+  }
+
+  public async get<T>(key: string): Promise<T | undefined> {
+    const result: T | null | undefined = this.asyncLocalStorage.get<T>(key);
+
+    if (!isNullOrUndefined(result)) {
+      await this.args.hooks?.hit?.(key, undefined);
+    }
+
+    return result;
+  }
+
+  public async del(key: string): Promise<void> {
+    if (typeof key !== "string") {
+      return;
+    }
+    this.asyncLocalStorage.delete(key);
+    await this.args.hooks?.delete?.(key, undefined);
+  }
+
+  public async keys(pattern?: string): Promise<string[]> {
+    const keys = this.asyncLocalStorage.keys(pattern).sort();
+
+    return keys.map((key) => key.split(":h:")[0]);
+  }
+
+  public async reset(): Promise<void> {
+    this.asyncLocalStorage.clear();
+  }
+
+  public async mget<T>(...keys: string[]): Promise<Array<T | undefined>> {
+    const map = new Map<string, T | undefined>(keys.map((key) => [key, undefined]));
+
+    for (const key of map.keys()) {
+      const result = this.asyncLocalStorage.get(key);
+      if (!isNullOrUndefined(result)) {
+        map.set(key, result);
+        await this.args.hooks?.hit?.(key, undefined);
+      }
+    }
+
+    return [...map.values()];
+  }
+
+  public async mset<T>(keyOrValues: [string, T][], ttl?: number): Promise<void> {
+    if (isNullOrUndefined(ttl) && !isNullOrUndefined(this.args.ttl)) {
+      ttl = this.args.ttl;
+    }
+
+    if (ttl === 0) {
+      return;
+    }
+
+    for (const [key, value] of keyOrValues) {
+      if (typeof key !== "string") {
+        continue;
+      }
+
+      if (isNullOrUndefined(value)) {
+        continue;
+      }
+
+      await this.args.hooks?.set?.(key, undefined, value, ttl);
+
+      this.asyncLocalStorage.set(key, value);
+    }
+  }
+
+  public async mdel(...keys: string[]): Promise<void> {
+    for (const key of keys) {
+      this.asyncLocalStorage.delete(key);
+      await this.args.hooks?.delete?.(key, undefined);
+    }
+  }
+
+  public async hget<T>(key: string, field: string): Promise<T | undefined> {
+    if (typeof key !== "string" || typeof field !== "string") {
+      return;
+    }
+
+    const asyncLocalStorageKey = `${key}:h:${field}`;
+
+    const result: T | null | undefined = this.asyncLocalStorage.get<T>(asyncLocalStorageKey);
+
+    if (!isNullOrUndefined(result)) {
+      await this.args.hooks?.hit?.(key, field);
+    }
+
+    await this.args.hooks?.hit?.(key, field);
+
+    return result;
+  }
+
+  public async hset<T>(key: string, field: string, value: T): Promise<void> {
+    if (typeof key !== "string" || typeof field !== "string" || isNullOrUndefined(value)) {
+      return;
+    }
+
+    const asyncLocalStorageKey = `${key}:h:${field}`;
+
+    this.asyncLocalStorage.set(asyncLocalStorageKey, value);
+
+    await this.args.hooks?.set?.(key, field, value, undefined);
+  }
+
+  public async hdel(key: string, ...fields: string[]): Promise<void> {
+    if (typeof key !== "string") {
+      return;
+    }
+    for (const field of fields) {
+      this.asyncLocalStorage.delete(`${key}:h:${field}`);
+      await this.args.hooks?.delete?.(key, field);
+    }
+  }
+
+  public async hgetall(key: string): Promise<Record<string, any>> {
+    const results: Record<string, any> = {};
+    if (typeof key !== "string") {
+      return results;
+    }
+    const hkey = `${key}:h:`;
+    const keys = this.asyncLocalStorage.keys(`${hkey}*`);
+
+    for (const key of keys) {
+      const field = key.replace(hkey, "");
+      results[field] = this.asyncLocalStorage.get(key);
+    }
+
+    return results;
+  }
+
+  public async hkeys(key: string): Promise<string[]> {
+    if (typeof key !== "string") {
+      return [];
+    }
+
+    const hkey = `${key}:h:`;
+    const keys = this.asyncLocalStorage.keys(`${hkey}*`);
+    return keys.map((key) => key.replace(hkey, ""));
+  }
+
+  public async close(): Promise<void> {
+    this.asyncLocalStorage.clear();
+  }
+}
+
+export function asyncLocalStorageStore(args: AsyncLocalStorageStoreArgs): AsyncLocalStorageStore {
+  return new AsyncLocalStorageStore(args);
+}

--- a/packages/cache-manager-async-local-storage/tsconfig.build.json
+++ b/packages/cache-manager-async-local-storage/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "test", "**/*spec.ts", "src/test.utils.ts", "dist"]
+}

--- a/packages/cache-manager-async-local-storage/tsconfig.json
+++ b/packages/cache-manager-async-local-storage/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./"
+  },
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cache-manager-ioredis/src/store.spec.ts
+++ b/packages/cache-manager-ioredis/src/store.spec.ts
@@ -1,7 +1,7 @@
+import { AsyncLocalStorageService } from "@anchan828/nest-cache-common";
 import { AsyncLocalStorage } from "async_hooks";
 import Redis from "ioredis";
 import { pack, unpack } from "msgpackr";
-import { AsyncLocalStorageService } from "./async-local-storage.service";
 import { RedisStore, redisStore } from "./store";
 describe.each([
   { name: "ioredis", client: new Redis({ db: 1, port: 6379, host: process.env.REDIS_HOST || "localhost" }) },

--- a/packages/cache-manager-ioredis/src/store.ts
+++ b/packages/cache-manager-ioredis/src/store.ts
@@ -1,8 +1,7 @@
 /* eslint-disable prefer-rest-params */
-import { CacheManager, chunk, isNullOrUndefined } from "@anchan828/nest-cache-common";
+import { AsyncLocalStorageService, CacheManager, chunk, isNullOrUndefined } from "@anchan828/nest-cache-common";
 import Redis from "ioredis";
 import { pack, unpack } from "msgpackr";
-import { AsyncLocalStorageService } from "./async-local-storage.service";
 import { CACHE_STORE_NAME } from "./constants";
 import { RedisStoreArgs } from "./store.interface";
 export class RedisStore implements CacheManager {


### PR DESCRIPTION
## Description

AsyncLocalStorage store for node-cache-manager.


## Quick Start

```ts
import { asyncLocalStorageStore } from "@anchan828/nest-cache-manager-async-local-storage";
import { caching } from "cache-manager";
const asyncLocalStorage = new AsyncLocalStorage<Map<string, any>>();
const cache = caching({
  store: asyncLocalStorageStore,
  asyncLocalStorage,
});
asyncLocalStorage.run(new Map<string, any>(), () => {
  cache.get("key");
});
```

## Notes

- This package is a cache function that is enabled only during a request using AsyncLocalStorage.
  - It is useful when the same data is retrieved from the database many times during a request, although it does not need to be cached permanently, such as in memory or Redis.
